### PR TITLE
fix: restore loading app index routing

### DIFF
--- a/front_end/static/loading/src/App.tsx
+++ b/front_end/static/loading/src/App.tsx
@@ -11,15 +11,14 @@ import LoadingPage from "./components/LoadingPage";
 
 const queryClient = new QueryClient();
 
-const App = () => {
+interface AppProps {
+  targetPath: string;
+}
+
+const App: React.FC<AppProps> = ({ targetPath }) => {
   const [loading, setLoading] = useState(true);
-  const [targetPath, setTargetPath] = useState("/");
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const target = params.get("target") || "/";
-    setTargetPath(target);
-
     const app = "loading";
 
     const checkAssets = async () => {
@@ -73,8 +72,11 @@ const App = () => {
         ) : (
           <BrowserRouter basename="/static/apps/loading/">
             <Routes>
-              <Route path="/" element={<Index />} />
-              <Route path="/users/:eth_address" element={<LoadingPage onComplete={() => setLoading(false)} />} />
+              <Route path="/" element={<Index targetPath={targetPath} />} />
+              <Route
+                path="/users/:eth_address"
+                element={<LoadingPage onComplete={() => setLoading(false)} />}
+              />
               <Route path="*" element={<NotFound />} />
             </Routes>
           </BrowserRouter>

--- a/front_end/static/loading/src/pages/Index.tsx
+++ b/front_end/static/loading/src/pages/Index.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+
+interface IndexProps {
+  targetPath: string;
+}
+
+const Index: React.FC<IndexProps> = ({ targetPath }) => {
+  useEffect(() => {
+    window.location.href = targetPath;
+  }, [targetPath]);
+
+  return null;
+};
+
+export default Index;


### PR DESCRIPTION
## Summary
- add Index page to redirect to requested path after assets load
- accept `targetPath` prop in `App` and pass to Index route

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b5ec9a7a48327baf0237c1d1f5b95