### PR TITLE
Define explicit blueprints for setup service routes

### DIFF
--- a/setup/api/routes/__init__.py
+++ b/setup/api/routes/__init__.py
@@ -1,4 +1,4 @@
-from flask import Blueprint
+"""Route blueprints for the setup service."""
 
-# Define the main blueprint for views
-blueprint = Blueprint('main', __name__)
+# Individual blueprints are defined in their respective modules and imported
+# by the application factory as needed.

--- a/setup/api/routes/federated.py
+++ b/setup/api/routes/federated.py
@@ -1,15 +1,21 @@
-import uuid
+"""Routes for managing federations of systems."""
+
 import os
-from flask import request, jsonify
-from . import blueprint
+import uuid
+from flask import Blueprint, jsonify, request
+
 from services.state import federations, systems
 from utils.common import generate_id
+
+# Similar to ``kerberos_bp``, expose ``federated_bp`` for registration in the
+# application factory.
+federated_bp = Blueprint("federated", __name__)
 
 
 # ---------------------------
 # 1. Join Existing Federation
 # ---------------------------
-@blueprint.route('/federate/join', methods=['POST'])
+@federated_bp.route('/federate/join', methods=['POST'])
 def join_federation():
     data = request.json
     federation_id = data.get("federation_id")
@@ -34,7 +40,7 @@ def join_federation():
 # ---------------------------
 # 2. Deploy Standalone System
 # ---------------------------
-@blueprint.route('/federate/standalone', methods=['POST'])
+@federated_bp.route('/federate/standalone', methods=['POST'])
 def create_standalone():
     data = request.json
     system_id = generate_id()
@@ -49,7 +55,7 @@ def create_standalone():
 # ---------------------------
 # 3. Create New Federation
 # ---------------------------
-@blueprint.route('/federate/create', methods=['POST'])
+@federated_bp.route('/federate/create', methods=['POST'])
 def create_federation():
     data = request.json
     federation_id = generate_id()
@@ -77,13 +83,13 @@ def create_federation():
 # ---------------------------
 # View All Federations
 # ---------------------------
-@blueprint.route('/federate/list', methods=['GET'])
+@federated_bp.route('/federate/list', methods=['GET'])
 def list_federations():
     return jsonify(federations)
 
 # ---------------------------
 # View All Systems
 # ---------------------------
-@blueprint.route('/federate/systems', methods=['GET'])
+@federated_bp.route('/federate/systems', methods=['GET'])
 def list_systems():
     return jsonify(systems)

--- a/setup/api/routes/kerberos.py
+++ b/setup/api/routes/kerberos.py
@@ -1,16 +1,28 @@
-from flask import jsonify
-from services.kerberos import write_conf, init_kdc, create_principal
-from . import blueprint
+"""Kerberos-related API routes."""
+
+from flask import Blueprint, jsonify
+
+from services.kerberos import create_principal, init_kdc, write_conf
+
+# Each route module exposes its own blueprint so the application factory can
+# register them individually. This module defines the blueprint expected by the
+# application: ``kerberos_bp``.
+kerberos_bp = Blueprint("kerberos", __name__)
 
 
-@blueprint.route('/kerberos/write_conf', methods=['POST'])
+@kerberos_bp.route("/kerberos/write_conf", methods=["POST"])
 def write_krb5_conf_route():
+    """Write the Kerberos configuration file."""
     return jsonify(write_conf())
 
-@blueprint.route('/kerberos/init_kdc', methods=['POST'])
+
+@kerberos_bp.route("/kerberos/init_kdc", methods=["POST"])
 def init_kdc_route():
+    """Initialise the Kerberos KDC."""
     return jsonify(init_kdc())
 
-@blueprint.route('/kerberos/create_principal', methods=['POST'])
+
+@kerberos_bp.route("/kerberos/create_principal", methods=["POST"])
 def create_principal_route():
+    """Create a Kerberos principal."""
     return jsonify(create_principal())


### PR DESCRIPTION
## Summary
- expose `kerberos_bp` and `federated_bp` blueprints in setup service
- clean up routes package init file and add helpful docstrings

## Testing
- `cd setup && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b64dd602883278d497e78c7837f04