### PR TITLE
feat: expose setup service port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,10 +173,12 @@ services:
   setup:
     build:
       context: ./setup
+    ports:
+      - "5000:5000"
     volumes:
-    - ./kerberos/output:/kerberos/output
-    - ./kerberos/kdc-data:/var/lib/krb5kdc
-    - ./kerberos/kdc-conf:/etc/krb5kdc
+      - ./kerberos/output:/kerberos/output
+      - ./kerberos/kdc-data:/var/lib/krb5kdc
+      - ./kerberos/kdc-conf:/etc/krb5kdc
     env_file:
       - .env
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- expose setup container on port 5000 in docker-compose
- fix indentation and trailing newline in docker-compose

## Testing
- `PYTHONPATH=. pytest tests` (front_end) *(fails: Config missing `WEBTORRENT_CONTAINER_URL`)*
- `PYTHONPATH=. pytest tests` (webtorrent) *(fails: FileNotFoundError on `/app/uploads/video.mp4`)*
- `PYTHONPATH=. pytest tests` (database) *(fails: could not translate host name "database")*
- `PYTHONPATH=. pytest tests` (rtmp)
- `PYTHONPATH=. pytest tests` (contract_manager)
- `PYTHONPATH=. pytest tests` (setup) *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689baae8578083279411e7de482f6ae7